### PR TITLE
Add asar to release pipeline for windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,6 @@ bower_components
 .DS_Store
 Thumbs.db
 /build/
+/dist/
 /releases/
 /tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,5 @@ bower_components
 .DS_Store
 Thumbs.db
 /build/
-/dist/
 /releases/
 /tmp/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "gulp-util": "^3.0.1",
     "q": "^1.0.1",
     "vinyl-map": "^1.0.1",
-    "yargs": "^1.3.1"
+    "yargs": "^1.3.1",
+    "asar": "^0.6.1"
   },
   "optionalDependencies": {
     "appdmg": "^0.3.1",
@@ -20,8 +21,5 @@
     "release": "./node_modules/.bin/gulp release --env=production",
     "start": "node ./tasks/start",
     "test": "node ./tasks/start --env=test"
-  },
-  "dependencies": {
-    "asar": "^0.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
     "release": "./node_modules/.bin/gulp release --env=production",
     "start": "node ./tasks/start",
     "test": "node ./tasks/start --env=test"
+  },
+  "dependencies": {
+    "asar": "^0.6.1"
   }
 }

--- a/tasks/release_windows.js
+++ b/tasks/release_windows.js
@@ -32,15 +32,11 @@ var copyRuntime = function () {
 var packageBuiltApp = function () {
     var deferred = Q.defer();
 
-    asar.createPackage(projectDir.cwd('build').path(), projectDir.cwd('dist').path() + '/app.asar', function() {
+    asar.createPackage(projectDir.cwd('build').path(), codeDir.path() + '/app.asar', function() {
         deferred.resolve();
     });
 
     return deferred.promise;
-};
-
-var copyBuiltApp = function () {
-    return projectDir.copyAsync('dist', codeDir.path(), { overwrite: true });
 };
 
 var finalize = function () {
@@ -103,7 +99,6 @@ module.exports = function () {
     return init()
     .then(copyRuntime)
     .then(packageBuiltApp)
-    .then(copyBuiltApp)
     .then(finalize)
     .then(createInstaller)
     .then(cleanClutter);


### PR DESCRIPTION
This pull request is a proposal to add asar to the release pipeline for Windows OS. Without it files with a name longer than~255 chars (not too hard with npm's nested depencies) cannot be installed (you could ignore it while installing but the app may not work properly after).

Maybe the whole process could be handled better but this is a working starting point, let me know if this makes sense!