### PR TITLE
display app version in OS X Finder 'Get Info' window

### DIFF
--- a/resources/osx/Info.plist
+++ b/resources/osx/Info.plist
@@ -18,6 +18,8 @@
 	<string>APPL</string>
 	<key>CFBundleVersion</key>
 	<string>{{version}}</string>
+        <key>CFBundleGetInfoString</key>
+        <string>{{version}}</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>10.8.0</string>
 	<key>NSMainNibFile</key>


### PR DESCRIPTION
Currently, when a Mac OS X user single-click in the Finder on an electron-boilerplate application built with "npm run release" and presses Command-I, the Finder "Get Info" window shows "Version: -".

This patch causes the version of the electron-boilerplate app to be displayed in the Finder "Get Info" window instead.