### PR TITLE
Update menu accelerators for cross platform compatibility.

### DIFF
--- a/app/vendor/electron_boilerplate/dev_helper.js
+++ b/app/vendor/electron_boilerplate/dev_helper.js
@@ -9,19 +9,19 @@ module.exports.setDevMenu = function () {
         label: 'Development',
         submenu: [{
             label: 'Reload',
-            accelerator: 'Command+R',
+            accelerator: 'CmdOrCtrl+R',
             click: function () {
                 BrowserWindow.getFocusedWindow().reloadIgnoringCache();
             }
         },{
             label: 'Toggle DevTools',
-            accelerator: 'Alt+Command+I',
+            accelerator: 'Alt+CmdOrCtrl+I',
             click: function () {
                 BrowserWindow.getFocusedWindow().toggleDevTools();
             }
         },{
             label: 'Quit',
-            accelerator: 'Command+Q',
+            accelerator: 'CmdOrCtrl+Q',
             click: function () {
                 app.quit();
             }


### PR DESCRIPTION
Simple update to be able to use the development menu accelerators on Windows and Linux and to remove the accelerator warnings on these platforms:
[584:0617/135533:WARNING:accelerator_util.cc(185)] Invalid accelerator token: command
[584:0617/135533:WARNING:accelerator_util.cc(185)] Invalid accelerator token: command
[584:0617/135533:WARNING:accelerator_util.cc(185)] Invalid accelerator token: command