### PR TITLE
Allows users to override the default location of the Electron runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ It will start the packaging process for operating system you are running this co
 
 You can create Windows installer only when running on Windows, the same is true for Linux and OSX. So to generate all three installers you need all three operating systems.
 
+## Overriding location of Electron runtime
+
+By default, the `npm run release` command will create a new build using the Electron runtime that is automatically installed by the `electron-prebuilt` package. If for some reason you need to override this behavior and explicitly specify the location of the desired runtime (e.g. you want to create a Windows build for 32-bit architecture on a 64-bit machine), you can do so by setting a value for `runtimePath` in the `package.json` file located in the root folder of this project:
+
+```
+{
+  "runtimePath": "/temp/electron/Electron.app"
+}
+```
+
 
 ## Special precautions for Windows
 As installer [NSIS](http://nsis.sourceforge.net/Main_Page) is used. You have to install it (version 3.0), and add NSIS folder to PATH in Environment Variables, so it is reachable to scripts in this project (path should look something like `C:/Program Files (x86)/NSIS`).

--- a/tasks/release_linux.js
+++ b/tasks/release_linux.js
@@ -28,7 +28,7 @@ var init = function () {
 };
 
 var copyRuntime = function () {
-    return projectDir.copyAsync('node_modules/electron-prebuilt/dist', readyAppDir.path(), { overwrite: true });
+    return projectDir.copyAsync(utils.getRuntimePath(), readyAppDir.path(), { overwrite: true });
 };
 
 var packageBuiltApp = function () {

--- a/tasks/release_osx.js
+++ b/tasks/release_osx.js
@@ -23,7 +23,8 @@ var init = function () {
 };
 
 var copyRuntime = function () {
-    return projectDir.copyAsync('node_modules/electron-prebuilt/dist/Electron.app', finalAppDir.path());
+    console.log('copying runtime from: %s', utils.getRuntimePath());
+    return projectDir.copyAsync(utils.getRuntimePath(), finalAppDir.path());
 };
 
 var cleanupRuntime = function() {

--- a/tasks/release_windows.js
+++ b/tasks/release_windows.js
@@ -24,7 +24,7 @@ var init = function () {
 };
 
 var copyRuntime = function () {
-    return projectDir.copyAsync('node_modules/electron-prebuilt/dist', readyAppDir.path(), { overwrite: true });
+    return projectDir.copyAsync(utils.getRuntimePath(), readyAppDir.path(), { overwrite: true });
 };
 
 var cleanupRuntime = function() {

--- a/tasks/utils.js
+++ b/tasks/utils.js
@@ -28,7 +28,26 @@ module.exports.getEnvName = function () {
     return argv.env || 'development';
 };
 
+module.exports.getManifest = function () {
+    return jetpack.read(__dirname + '/../package.json', 'json');
+};
+
 module.exports.getElectronVersion = function () {
-    var manifest = jetpack.read(__dirname + '/../package.json', 'json');
-    return manifest.devDependencies['electron-prebuilt'].substring(1);
+    return module.exports.getManifest().devDependencies['electron-prebuilt'].substring(1);
+};
+
+module.exports.getRuntimePath = function () {
+    var runtimePath = module.exports.getManifest().runtimePath;
+    switch (module.exports.os()) {
+        case 'osx':
+            return runtimePath || 'node_modules/electron-prebuilt/dist/Electron.app';
+        break;
+        case 'linux':
+        case 'windows':
+            return runtimePath || 'node_modules/electron-prebuilt/dist';
+        break;
+        default:
+            throw new Error('Unsupported os: ' + module.exports.os());
+        break;
+    }
 };


### PR DESCRIPTION
@szwacz This PR provides a method for resolving the issue outlined in #30 (32 bit builds?). With this PR, users have the ability to manually override the location of the desired Electron runtime by specifying a value for `runtimePath` in the `package.json` file located in the root of the project.

Thoughts?