### PR TITLE
Accept spaces in the app Path

### DIFF
--- a/tasks/release_linux.js
+++ b/tasks/release_linux.js
@@ -86,7 +86,7 @@ var packToDebFile = function () {
     packDir.write('DEBIAN/control', control);
 
     // Build the package...
-    childProcess.exec('fakeroot dpkg-deb -Zxz --build ' + packDir.path() + ' ' + debPath,
+    childProcess.exec('fakeroot dpkg-deb -Zxz --build ' + packDir.path().replace(/\s/, '\\ ') + ' ' + debPath.replace(/\s/, '\\ '),
         function (error, stdout, stderr) {
             if (error || stderr) {
                 console.log("ERROR while building DEB package:");

--- a/tasks/release_linux.js
+++ b/tasks/release_linux.js
@@ -86,7 +86,7 @@ var packToDebFile = function () {
     packDir.write('DEBIAN/control', control);
 
     // Build the package...
-    childProcess.exec('fakeroot dpkg-deb -Zxz --build ' + packDir.path().replace(/\s/, '\\ ') + ' ' + debPath.replace(/\s/, '\\ '),
+    childProcess.exec('fakeroot dpkg-deb -Zxz --build ' + packDir.path().replace(/\s/g, '\\ ') + ' ' + debPath.replace(/\s/g, '\\ '),
         function (error, stdout, stderr) {
             if (error || stderr) {
                 console.log("ERROR while building DEB package:");


### PR DESCRIPTION
Add support for spaces in the path when building the app's executable for Linux.