### PR TITLE
Fixed typographical error, changed aplication to application in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Comprehensive boilerplate application for [Electron runtime](http://electron.ato
 
 Scope of this project:
 
-- Provide basic structure of the aplication so you can much easier grasp what goes where.
+- Provide basic structure of the application so you can much easier grasp what goes where.
 - Give cross-platform development environment, which works the same way on OSX, Windows and Linux.
 - Generate ready for distribution installers of your app for all supported operating systems.
 


### PR DESCRIPTION
@szwacz, I've corrected a typographical error in the documentation of the [electron-boilerplate](https://github.com/szwacz/electron-boilerplate) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.