### PR TITLE
Added "Path" to the app.desktop for Linux

### DIFF
--- a/resources/linux/app.desktop
+++ b/resources/linux/app.desktop
@@ -5,6 +5,7 @@ Encoding=UTF-8
 Name={{productName}}
 Comment={{description}}
 Exec=/opt/{{name}}/{{name}}
+Path=/opt/{{name}}/
 Icon=/opt/{{name}}/icon.png
 Terminal=false
 Categories=Application;


### PR DESCRIPTION
Without this path being set some problems can arise when running without a terminal (specifically Ubuntu Unity).