### PR TITLE
Catch error at the end of the promise chain

### DIFF
--- a/tasks/release_windows.js
+++ b/tasks/release_windows.js
@@ -123,5 +123,6 @@ module.exports = function () {
     .then(finalize)
     .then(renameApp)
     .then(createInstaller)
-    .then(cleanClutter);
+    .then(cleanClutter)
+    .catch(console.error);
 };


### PR DESCRIPTION
Errors during the windows release are silent. By adding a catch at the end of the promise chain, there are now logged into the console.