### PR TITLE
Fix npm scripts path references

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
   "scripts": {
     "postinstall": "node ./tasks/app_npm_install",
     "app-install": "node ./tasks/app_npm_install",
-    "build": "./node_modules/.bin/gulp build",
-    "release": "./node_modules/.bin/gulp release --env=production",
+    "build": "gulp build",
+    "release": "gulp release --env=production",
     "start": "node ./tasks/start",
     "test": "node ./tasks/start --env=test"
   }


### PR DESCRIPTION
npm scripts do not need to explicitly reference
'node_modules/.bin/script'. The portable way to reference npm
installed "binaries" is to simply use their name.

https://docs.npmjs.com/misc/scripts#path
http://blog.ibangspacebar.com/npm-scripts/