### PR TITLE
Elevate installer

### DIFF
--- a/resources/windows/installer.nsi
+++ b/resources/windows/installer.nsi
@@ -36,6 +36,7 @@ OutFile "${dest}"
 InstallDir "$PROGRAMFILES\${productName}"
 InstallDirRegKey HKLM "${regkey}" ""
 
+RequestExecutionLevel admin
 CRCCheck on
 SilentInstall normal
 


### PR DESCRIPTION
With `InstallDir` defaulting to Program Files, installers on modern Windows (Vista and later) will require elevated rights to write files.