### PR TITLE
Updating NSIS

### DIFF
--- a/resources/windows/installer.nsi
+++ b/resources/windows/installer.nsi
@@ -36,6 +36,7 @@ OutFile "${dest}"
 InstallDir "$PROGRAMFILES\${productName}"
 InstallDirRegKey HKLM "${regkey}" ""
 
+RequestExecutionLevel admin
 CRCCheck on
 SilentInstall normal
 

--- a/resources/windows/installer.nsi
+++ b/resources/windows/installer.nsi
@@ -36,6 +36,7 @@ OutFile "${dest}"
 InstallDir "$PROGRAMFILES\${productName}"
 InstallDirRegKey HKLM "${regkey}" ""
 
+Unicode true
 RequestExecutionLevel admin
 CRCCheck on
 SilentInstall normal

--- a/resources/windows/installer.nsi
+++ b/resources/windows/installer.nsi
@@ -28,7 +28,7 @@
 ; Installation
 ; --------------------------------
 
-SetCompressor lzma
+SetCompressor /SOLID lzma
 
 Name "${productName}"
 Icon "${setupIcon}"


### PR DESCRIPTION
Sorry for the duplicate pull-request, here's a new one with all my changes to the install script

* with `InstallDir` defaulting to *Program Files*, installers on modern Windows (Vista and later) will require elevated rights to write files (c52483b)

* as NSIS 3.0 is recommended, installers should make use of its Unicode support. This means less problems with foreign Electron apps (c7f85e3)

* minor change, improving the compression of the installer (d5a647d)

I wonder if there's a specific reason, why not to let the user specify the install location?