### PR TITLE
Added extra info to installer for Windows

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,7 @@
 {
   "name": "electron-boilerplate",
   "productName": "Electron Boilerplate",
+  "companyName": "Boilerplate Corporation",
   "identifier": "com.example.electron-boilerplate",
   "description": "Starter for your Electron application. Out of the box ready for serious stuff.",
   "version": "0.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,6 @@
 {
   "name": "electron-boilerplate",
   "productName": "Electron Boilerplate",
-  "companyName": "Boilerplate Corporation",
   "identifier": "com.example.electron-boilerplate",
   "description": "Starter for your Electron application. Out of the box ready for serious stuff.",
   "version": "0.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -1,11 +1,10 @@
 {
   "name": "electron-boilerplate",
   "productName": "Electron Boilerplate",
-  "companyName": "Boilerplate Corporation",
   "identifier": "com.example.electron-boilerplate",
   "description": "Starter for your Electron application. Out of the box ready for serious stuff.",
   "version": "0.1.0",
-  "author": "Mr Gumby <gumby@sillywalks.com>",
+  "author": "Mr Gumby",
   "main": "background.js",
   "dependencies": {
     "fs-jetpack": "^0.7.0"

--- a/resources/windows/installer.nsi
+++ b/resources/windows/installer.nsi
@@ -12,6 +12,7 @@
 !define src "{{src}}"
 !define name "{{name}}"
 !define productName "{{productName}}"
+!define companyName "{{companyName}}"
 !define version "{{version}}"
 !define icon "{{icon}}"
 !define setupIcon "{{setupIcon}}"
@@ -90,6 +91,8 @@ Section "Install"
     WriteRegStr HKLM "${uninstkey}" "DisplayName" "${productName}"
     WriteRegStr HKLM "${uninstkey}" "DisplayIcon" '"$INSTDIR\icon.ico"'
     WriteRegStr HKLM "${uninstkey}" "UninstallString" '"$INSTDIR\${uninstaller}"'
+    WriteRegStr HKLM "${uninstkey}" "Publisher" "${companyName}"
+    WriteRegStr HKLM "${uninstkey}" "DisplayVersion" "${version}"
 
     ; Remove all application files copied by previous installation
     RMDir /r "$INSTDIR"

--- a/resources/windows/installer.nsi
+++ b/resources/windows/installer.nsi
@@ -12,7 +12,6 @@
 !define src "{{src}}"
 !define name "{{name}}"
 !define productName "{{productName}}"
-!define companyName "{{companyName}}"
 !define version "{{version}}"
 !define icon "{{icon}}"
 !define setupIcon "{{setupIcon}}"
@@ -91,8 +90,6 @@ Section "Install"
     WriteRegStr HKLM "${uninstkey}" "DisplayName" "${productName}"
     WriteRegStr HKLM "${uninstkey}" "DisplayIcon" '"$INSTDIR\icon.ico"'
     WriteRegStr HKLM "${uninstkey}" "UninstallString" '"$INSTDIR\${uninstaller}"'
-    WriteRegStr HKLM "${uninstkey}" "Publisher" "${companyName}"
-    WriteRegStr HKLM "${uninstkey}" "DisplayVersion" "${version}"
 
     ; Remove all application files copied by previous installation
     RMDir /r "$INSTDIR"

--- a/resources/windows/installer.nsi
+++ b/resources/windows/installer.nsi
@@ -12,7 +12,7 @@
 !define src "{{src}}"
 !define name "{{name}}"
 !define productName "{{productName}}"
-!define companyName "{{companyName}}"
+!define author "{{author}}"
 !define version "{{version}}"
 !define icon "{{icon}}"
 !define setupIcon "{{setupIcon}}"
@@ -91,7 +91,7 @@ Section "Install"
     WriteRegStr HKLM "${uninstkey}" "DisplayName" "${productName}"
     WriteRegStr HKLM "${uninstkey}" "DisplayIcon" '"$INSTDIR\icon.ico"'
     WriteRegStr HKLM "${uninstkey}" "UninstallString" '"$INSTDIR\${uninstaller}"'
-    WriteRegStr HKLM "${uninstkey}" "Publisher" "${companyName}"
+    WriteRegStr HKLM "${uninstkey}" "Publisher" "${author}"
     WriteRegStr HKLM "${uninstkey}" "DisplayVersion" "${version}"
 
     ; Remove all application files copied by previous installation

--- a/resources/windows/installer.nsi
+++ b/resources/windows/installer.nsi
@@ -100,6 +100,7 @@ Section "Install"
     File /r "${src}\*"
 
     ; Create start menu shortcut
+    SetShellVarContext all
     CreateShortCut "$SMPROGRAMS\${productName}.lnk" "$INSTDIR\${exec}" "" "$INSTDIR\icon.ico"
 
     WriteUninstaller "${uninstaller}"
@@ -149,6 +150,7 @@ Section "Uninstall"
     DeleteRegKey HKLM "${uninstkey}"
     DeleteRegKey HKLM "${regkey}"
 
+    SetShellVarContext all
     Delete "$SMPROGRAMS\${productName}.lnk"
 
     ; Remove whole directory from Program Files

--- a/tasks/release_windows.js
+++ b/tasks/release_windows.js
@@ -75,7 +75,6 @@ var createInstaller = function () {
     installScript = utils.replace(installScript, {
         name: manifest.name,
         productName: manifest.productName,
-        companyName: manifest.companyName,
         version: manifest.version,
         src: readyAppDir.path(),
         dest: releasesDir.path(finalPackageName),

--- a/tasks/release_windows.js
+++ b/tasks/release_windows.js
@@ -75,6 +75,7 @@ var createInstaller = function () {
     installScript = utils.replace(installScript, {
         name: manifest.name,
         productName: manifest.productName,
+        companyName: manifest.companyName,
         version: manifest.version,
         src: readyAppDir.path(),
         dest: releasesDir.path(finalPackageName),

--- a/tasks/release_windows.js
+++ b/tasks/release_windows.js
@@ -72,10 +72,29 @@ var createInstaller = function () {
 
     var finalPackageName = manifest.name + '_' + manifest.version + '.exe';
     var installScript = projectDir.read('resources/windows/installer.nsi');
+
+    var finalAuthorName = function(rawAuthorValue) {
+        var defaultEmptyAuthorValue = "";
+
+        if (!rawAuthorValue) {
+            return defaultEmptyAuthorValue;
+        } else {
+            switch (typeof rawAuthorValue) {
+                case 'string':
+                    return rawAuthorValue;
+                case 'object':
+                    // Extracting name from "author" object
+                    return rawAuthorValue.name || defaultEmptyAuthorValue;
+                default:
+                    return defaultEmptyAuthorValue;
+            }
+        }
+    }(manifest.author);
+
     installScript = utils.replace(installScript, {
         name: manifest.name,
         productName: manifest.productName,
-        companyName: manifest.companyName,
+        author: finalAuthorName,
         version: manifest.version,
         src: readyAppDir.path(),
         dest: releasesDir.path(finalPackageName),


### PR DESCRIPTION
Hi, I've added "companyName" and version number to NSIS's configuration. Both values are coming from app's "package.json".

That information will be visible in this menu:
![prog-fea](https://cloud.githubusercontent.com/assets/1118784/11910355/a444f518-a5a9-11e5-8d90-8dac92212440.jpg)
"companyName" --> "Publisher" column
version --> "Version" column
