### PR TITLE
Fix: electron-prebuilt version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "asar": "^0.7.2",
-    "electron-prebuilt": "^0.35.1",
+    "electron-prebuilt": "^0.36.0",
     "fs-jetpack": "^0.7.0",
     "gulp": "^3.9.0",
     "gulp-less": "^3.0.3",


### PR DESCRIPTION
fix electron-prebuilt version from 0.35.1 to 0.36.0 in package.json