### PR TITLE
Add more details to executable for Windows and OS X

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -5,6 +5,7 @@
   "description": "Starter for your Electron application. Out of the box ready for serious stuff.",
   "version": "0.1.0",
   "author": "Mr Gumby",
+  "copyright": "© 2016, your company here",
   "main": "background.js",
   "dependencies": {
     "fs-jetpack": "^0.7.0"

--- a/resources/osx/Info.plist
+++ b/resources/osx/Info.plist
@@ -28,5 +28,7 @@
 	<string>AtomApplication</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>
 	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>{{copyright}}</string>
 </dict>
 </plist>

--- a/tasks/release_osx.js
+++ b/tasks/release_osx.js
@@ -49,7 +49,8 @@ var finalize = function () {
     info = utils.replace(info, {
         productName: manifest.productName,
         identifier: manifest.identifier,
-        version: manifest.version
+        version: manifest.version,
+        copyright: manifest.copyright
     });
     finalAppDir.write('Contents/Info.plist', info);
 

--- a/tasks/release_windows.js
+++ b/tasks/release_windows.js
@@ -53,6 +53,10 @@ var finalize = function () {
         'version-string': {
             'ProductName': manifest.productName,
             'FileDescription': manifest.description,
+            'ProductVersion': manifest.version,
+            'CompanyName': manifest.author, // it might be better to add another field to package.json for this
+            'LegalCopyright': manifest.copyright,
+            'OriginalFilename': manifest.productName + '.exe'
         }
     }, function (err) {
         if (!err) {


### PR DESCRIPTION
Adds following details to the installed exe's details (Windows):

* OriginalFilename (productName + .exe)
* LegalCopyright
* CompanyName
* ProductVersion

Adds following details to .app details (OS X):

* NSHumanReadableCopyright

Adds following fields to `app/package.json`:

* copyright