### PR TITLE
Added temporary work-around for #12.

### DIFF
--- a/tasks/start.js
+++ b/tasks/start.js
@@ -7,6 +7,7 @@ var childProcess = require('child_process');
 var kill = require('tree-kill');
 var utils = require('./utils');
 var watch;
+var shuttingDown = false;
 
 var gulpPath = pathUtil.resolve('./node_modules/.bin/gulp');
 
@@ -38,6 +39,10 @@ var runGulpWatch = function () {
     });
 
     watch.on('close', function (code) {
+
+        // If we are manually shutting down, stop here.
+        if (shuttingDown) return;
+      
         // Gulp watch exits when error occured during build.
         // Just respawn it then.
         runGulpWatch();
@@ -49,7 +54,10 @@ var runApp = function () {
         stdio: 'inherit'
     });
 
-    app.on('close', function (code) {
+    app.on('close', function(code) {
+        // Flag the current status so we don't auto-restart the other tasks.
+        shuttingDown = true;
+      
         // User closed the app. Kill the host process.
         kill(watch.pid, 'SIGKILL', function () {
             process.exit();


### PR DESCRIPTION
This just sets a flag to prevent the watch task from being restarted when the user closes the application. Probably not a perfect long-term solution, but a step in the right direction!

Credit goes out to @pkunze for finding the issue.