### PR TITLE
Add npm script to run gulp watch command.

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "postinstall": "cd app && npm install",
     "build": "gulp build",
+    "watch": "gulp watch",
     "release": "gulp release --env=production",
     "start": "gulp start",
     "pretest": "gulp build --env=test",


### PR DESCRIPTION
The watch command is undocumented and is not likely to be found, unless
you are looking for it.

This gives visibility to the command, and gives the interface (via npm)
more consistency.