### PR TITLE
remove warning about resolved mac app store issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ npm run release -- --sign A123456789
 ```
 
 #### Mac App Store
-**CAUTION**: until [atom/electron/issues#3871](https://github.com/atom/electron/issues/3871) isn't resolved, the signing procedure probably will make your application crash right after run.
 
 You should install the Electron build for MAS
 ```


### PR DESCRIPTION
https://github.com/electron/electron/issues/3871#issuecomment-211883141 was resolved a couple weeks [after this warning was added](https://github.com/szwacz/electron-boilerplate/commit/e484ccabd35c968a5ec8e288a26c9f4f46029f35) to the README.


