### PR TITLE
add asar: true (default behaviour)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "dmg": {
       "icon": "resources/osx/dmg-icon.icns",
       "background": "resources/osx/dmg-background.png"
-    }
+    },
+    "asar: true
   },
   "directories": {
     "buildResources": "resources"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
       "icon": "resources/osx/dmg-icon.icns",
       "background": "resources/osx/dmg-background.png"
     },
-    "asar: true
+    "asar: "true"
   },
   "directories": {
     "buildResources": "resources"


### PR DESCRIPTION
Documents how to disable asar.
asar by default (true)
false allows encapsulated code to use pure files so that the encapsulated code can use the filesystem and not the asar archieve