### PR TITLE
add "asar": true (default behaviour)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "dmg": {
       "icon": "resources/osx/dmg-icon.icns",
       "background": "resources/osx/dmg-background.png"
-    }
+    },
+    "asar": true
   },
   "directories": {
     "buildResources": "resources"


### PR DESCRIPTION
Indicates where to disable asar.
"asar" : true gives default behaviour, use of asar archieve
"asar": false, allows encapsulated code to use files files directly and not the asar archive

Owen Brotherwood