### PR TITLE
build app- key change

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "appId": "com.example.electron-boilerplate",
-    "app-category-type": "your.app.category.type",
+    "app-category": "your.app.category.type",
     "win": {
       "target": [
         "nsis"


### PR DESCRIPTION
Can be used if the dependencies for building for npm run release are changed to newer versions.
https://github.com/szwacz/electron-boilerplate/issues/232

Owen Brotherwood