### PR TITLE
Use path to join path instead of manually set path

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -3,6 +3,7 @@
 // It doesn't have any windows which you can see on screen, but we can open
 // window from here.
 
+import path from 'path'
 import { app, Menu } from 'electron';
 import { devMenuTemplate } from './menu/dev_menu_template';
 import { editMenuTemplate } from './menu/edit_menu_template';
@@ -38,7 +39,7 @@ app.on('ready', function () {
         height: 600
     });
 
-    mainWindow.loadURL('file://' + __dirname + '/app.html');
+    mainWindow.loadURL(path.join('file://', __dirname, '/app.html'));
 
     if (env.name === 'development') {
         mainWindow.openDevTools();

--- a/src/background.js
+++ b/src/background.js
@@ -4,6 +4,7 @@
 // window from here.
 
 import path from 'path'
+import url from 'url'
 import { app, Menu } from 'electron';
 import { devMenuTemplate } from './menu/dev_menu_template';
 import { editMenuTemplate } from './menu/edit_menu_template';
@@ -39,7 +40,11 @@ app.on('ready', function () {
         height: 600
     });
 
-    mainWindow.loadURL(path.join('file://', __dirname, '/app.html'));
+    mainWindow.loadURL(url.format({
+      pathname: path.join(__dirname, '/app.html'),
+      protocol: 'file:',
+      slashes: true
+    }));
 
     if (env.name === 'development') {
         mainWindow.openDevTools();


### PR DESCRIPTION
Using [node path module](https://nodejs.org/api/path.html) [`path.join()`](https://nodejs.org/api/path.html#path_path_join_paths) or [`path.resovle()`](https://nodejs.org/api/path.html#path_path_resolve_paths) is better then setting path manually.

What do you think 👀 @szwacz 