### PR TITLE
Upgrade electron-builder to 17.1.x (was 14.5.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "electron": "1.6.2",
-    "electron-builder": "^14.5.2",
+    "electron-builder": "^17.1.1",
     "electron-mocha": "^3.3.0",
     "gulp": "^3.9.1",
     "gulp-batch": "^1.0.5",


### PR DESCRIPTION
BREAKING CHANGES

    dmg/pkg in the out dir, not in the subdir mac
    if app version is like 0.12.1-alpha.1, file alpha.yml will be generated instead of latest.yml. Set detectUpdateChannel to false to disable this new behaviour.

Rest is bug fixes and new features.