### PR TITLE
Upgrade dependencies, fix breaking change in rollup

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ npm start
 The version of Electron runtime your app is using is declared in `package.json`:
 ```json
 "devDependencies": {
-  "electron": "1.6.6"
+  "electron": "1.6.11"
 }
 ```
 Side note: [Electron authors advise](http://electron.atom.io/docs/tutorial/electron-versioning/) to use fixed version here.

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.0",
-    "electron": "^1.7.4",
+    "electron": "^1.6.11",
     "electron-builder": "^19.16.0",
     "electron-mocha": "^4.0.0",
     "gulp": "^3.9.1",

--- a/package.json
+++ b/package.json
@@ -33,22 +33,22 @@
     "fs-jetpack": "^1.0.0"
   },
   "devDependencies": {
-    "chai": "^4.0.1",
-    "electron": "^1.6.11",
-    "electron-builder": "^19.5.1",
+    "chai": "^4.1.0",
+    "electron": "^1.7.4",
+    "electron-builder": "^19.16.0",
     "electron-mocha": "^4.0.0",
     "gulp": "^3.9.1",
     "gulp-batch": "^1.0.5",
-    "gulp-less": "^3.3.0",
+    "gulp-less": "^3.3.2",
     "gulp-plumber": "^1.1.0",
     "gulp-util": "^3.0.8",
     "gulp-watch": "^4.3.11",
     "istanbul": "^0.4.5",
     "minimist": "^1.2.0",
-    "mocha": "^3.2.0",
-    "rollup": "^0.43.0",
+    "mocha": "^3.4.2",
+    "rollup": "^0.45.2",
     "rollup-plugin-istanbul": "^1.1.0",
-    "source-map-support": "^0.4.11",
-    "spectron": "^3.6.4"
+    "source-map-support": "^0.4.15",
+    "spectron": "^3.7.2"
   }
 }

--- a/tasks/bundle.js
+++ b/tasks/bundle.js
@@ -39,17 +39,18 @@ module.exports = (src, dest, opts) => {
     cached[src] = bundle;
 
     const jsFile = path.basename(dest);
-    const result = bundle.generate({
+    return bundle.generate({
       format: 'cjs',
       sourceMap: true,
       sourceMapFile: jsFile,
-    });
-    // Wrap code in self invoking function so the constiables don't
-    // pollute the global namespace.
-    const isolatedCode = `(function () {${result.code}\n}());`;
-    return Promise.all([
-      jetpack.writeAsync(dest, `${isolatedCode}\n//# sourceMappingURL=${jsFile}.map`),
-      jetpack.writeAsync(`${dest}.map`, result.map.toString()),
-    ]);
+    }).then(result => {
+      // Wrap code in self invoking function so the constiables don't
+      // pollute the global namespace.
+      const isolatedCode = `(function () {${result.code}\n}());`;
+      return Promise.all([
+        jetpack.writeAsync(dest, `${isolatedCode}\n//# sourceMappingURL=${jsFile}.map`),
+        jetpack.writeAsync(`${dest}.map`, result.map.toString()),
+      ]);
+    })
   });
 };


### PR DESCRIPTION
Updates all project dependencies to their latest versions (16th July 2017). Then, adds fix for breaking change in rollup dependency suggested by @black-snow.