### PR TITLE
added an error handler to the rollup task in bundle.js

### DIFF
--- a/tasks/bundle.js
+++ b/tasks/bundle.js
@@ -52,5 +52,6 @@ module.exports = (src, dest, opts) => {
         jetpack.writeAsync(`${dest}.map`, result.map.toString()),
       ]);
     })
-  });
+  })
+  .catch(console.error);
 };

--- a/tasks/bundle.js
+++ b/tasks/bundle.js
@@ -53,5 +53,8 @@ module.exports = (src, dest, opts) => {
       ]);
     })
   })
-  .catch(console.error);
+  .catch(e => {
+    console.error(e);
+    throw e;
+  });
 };


### PR DESCRIPTION
Absence of an explicit error handler resulted in user not being able to access the rollup error messages during any break in the build process

Should ideally stop the build process as well. But this change will at least allow the dev to see and correct the error in the offending files.