### PR TITLE
Add typescript support

### DIFF
--- a/build/webpack.base.config.js
+++ b/build/webpack.base.config.js
@@ -4,7 +4,7 @@ const FriendlyErrorsWebpackPlugin = require("friendly-errors-webpack-plugin");
 
 module.exports = env => {
   return {
-    target: "node",
+    target: "electron",
     node: {
       __dirname: false,
       __filename: false
@@ -13,7 +13,8 @@ module.exports = env => {
     resolve: {
       alias: {
         env: path.resolve(__dirname, `../config/env_${env}.json`)
-      }
+      },
+      extensions: ['.ts', '.js']
     },
     devtool: "source-map",
     module: {
@@ -26,7 +27,8 @@ module.exports = env => {
         {
           test: /\.css$/,
           use: ["style-loader", "css-loader"]
-        }
+        },
+        { test: /\.ts$/, use: 'ts-loader', exclude: /node_modules/ }
       ]
     },
     plugins: [

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "babel-plugin-transform-object-rest-spread": "^7.0.0-beta.3",
     "chai": "^4.1.0",
     "css-loader": "^0.28.7",
-    "electron": "1.7.9",
+    "electron": "1.7.10",
     "electron-builder": "^19.43.3",
     "electron-mocha": "^5.0.0",
     "friendly-errors-webpack-plugin": "^1.6.1",
@@ -51,7 +51,7 @@
     "webpack": "^3.8.1",
     "webpack-merge": "^4.1.0",
     "webpack-node-externals": "^1.6.0",
-    "typescript": "^2.3.4",
+    "typescript": "^2.6.2",
     "ts-loader": "~2.3.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "style-loader": "^0.19.0",
     "webpack": "^3.8.1",
     "webpack-merge": "^4.1.0",
-    "webpack-node-externals": "^1.6.0"
+    "webpack-node-externals": "^1.6.0",
+    "typescript": "^2.3.4",
+    "ts-loader": "~2.3.7"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,54 @@
+{ 
+  "compileOnSave": true,
+  "compilerOptions": {
+    /* Basic Options */                       
+    "target": "es6",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'commonjs', 'amd', 'system', 'umd' or 'es2015'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation:  */
+    //"allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    "sourceMap": true,                        /* Generates corresponding '.map' file. */
+    //"outFile": "./renderer.js",              /* Concatenate and emit output to single file. */
+    // "outDir": "out-tsc",                           /* Redirect output structure to the directory. */
+    "rootDir": "src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+                                              
+    /* Strict Type-Checking Options */        
+    "strict": true,                       /* Enable all strict type-checking options. */
+    "noImplicitAny": false,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+                                              
+    /* Additional Checks */                   
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+                                              
+    /* Module Resolution Options */           
+    "moduleResolution": "node"               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": ["node_modules/@types"]                                         /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+                                              
+    /* Source Map Options */                  
+    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+                                              
+    /* Experimental Options */                
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  }
+}


### PR DESCRIPTION
Following the discussion on szwacz/electron-boilerplate#170, this pull request adds to `electron-boilerplate` the capacity to compile and package an application fully coded in TypeScript.

The `start`, `test` and `release` tasks show no regression in the presence of those modifications.

The most notable point is that I had to bump the `electron` version to 1.7.10 due to the recent introduction of stricter checks in the TypeScript compiler (electron/electron-typescript-definitions#79). Also I had to change the `webpack` target from `node` to `electron`.

I'd be pleased to make any adjustments you see fit in order for this to me merged.